### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,8 +322,10 @@
                     type: 'GET',
                     dataType: "json",
                     success: function (release) {
-                        latestRelease = release.tag_name;
-                        if (latestRelease !== json.current_version) {
+                        latestRelease = release.tag_name
+                        latestVersion = parseInt(release.tag_name.split('.').join(""));
+                        currentVersion = parseInt(json.current_version.split('.').join(""));
+                        if (latestVersion > currentVersion) {
                             $("#updateNotificationBar").html('<div class="alert alert-info alert-dismissable fade in">' +
                                 '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' +
                                 '<a href="https://github.com/Bendr0id/xmrigCC/releases/latest"><strong>Update!</strong> XMRigCC v' + latestRelease + ' is available for download\n</a>' +


### PR DESCRIPTION
Vars "latestVersion" and "currentVersion" hold parsed version strings to ints (e.g. 1.6.3 --> 163 & 1.6.4 --> 164). Alert is not raised in case that current (dev/beta/unreleased) version is newer than released one.
![screenshot_2018-06-12_22-19-56](https://user-images.githubusercontent.com/13107713/41316349-694eaca6-6e92-11e8-8706-607a7c154e9a.png)
