### PR TITLE
#1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Fix correct hugepages status on Dashboard
 - Fix cpu affinity for single thread usage
 - Add all needed security infos to XMRigCCServer logging to harden the server (f.e. fail2ban)
+- Fix commandline params overwrite config.json #157
+- Fix bulding of miner with API support Cannot #145
 # 1.6.5
 - Hashrate improve -> add autodetection mode for cpu-affinity
 - Hashrate improve, more stable hashrates -> refactor memory allocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Maximum lines of log history kept per miner can be configured on XMRigCCServer 
 - Fix correct hugepages status on Dashboard
 - Fix cpu affinity for single thread usage
+- Add all needed security infos to XMRigCCServer logging to harden the server (f.e. fail2ban)
 # 1.6.5
 - Hashrate improve -> add autodetection mode for cpu-affinity
 - Hashrate improve, more stable hashrates -> refactor memory allocation

--- a/src/cc/Httpd.h
+++ b/src/cc/Httpd.h
@@ -51,12 +51,12 @@ private:
 
     static int sendResponse(MHD_Connection* connection, unsigned status, MHD_Response* rsp, const char* contentType);
 
-    unsigned basicAuth(MHD_Connection* connection, std::string &resp);
-    unsigned tokenAuth(MHD_Connection* connection);
+    unsigned basicAuth(MHD_Connection* connection, const std::string& clientIp, std::string &resp);
+    unsigned tokenAuth(MHD_Connection* connection, const std::string& clientIp);
 
     static int handler(void* httpd, MHD_Connection* connection, const char* url, const char* method, const char* version, const char* upload_data, size_t* upload_data_size, void**con_cls);
-    static int handleGET(const Httpd* httpd, MHD_Connection* connection, const char* url);
-    static int handlePOST(const Httpd* httpd, MHD_Connection* connection, const char* url, const char* upload_data, size_t* upload_data_size, void** con_cls);
+    static int handleGET(const Httpd* httpd, MHD_Connection* connection, const std::string& clientIp, const char* url);
+    static int handlePOST(const Httpd* httpd, MHD_Connection* connection, const std::string& clientIp, const char* url, const char* upload_data, size_t* upload_data_size, void** con_cls);
 
 	static std::string readFile(const std::string &fileName);
 

--- a/src/cc/Service.cpp
+++ b/src/cc/Service.cpp
@@ -90,11 +90,12 @@ unsigned Service::handleGET(const Options* options, const std::string& url, cons
             } else if (url.rfind("/admin/getClientLog", 0) == 0) {
                 resultCode = getClientLog(clientId, resp);
             } else {
-                LOG_WARN("[%s] METHOD_NOT_FOUND (%s)", clientIp.c_str(), url.c_str());
+                LOG_WARN("[%s] 404 NOT FOUND (%s)", clientIp.c_str(), url.c_str());
             }
         }
         else {
-            LOG_ERR("[%s] Request does not contain clientId: %s", clientIp.c_str(), url.c_str());
+            resultCode = MHD_HTTP_BAD_REQUEST;
+            LOG_ERR("[%s] 400 BAD REQUEST - Request does not contain clientId (%s)", clientIp.c_str(), url.c_str());
         }
     }
 
@@ -128,13 +129,13 @@ unsigned Service::handlePOST(const Options* options, const std::string& url, con
         } else if (url.rfind("/admin/setClientCommand", 0) == 0) {
             resultCode = setClientCommand(clientId, data, resp);
         } else {
-            LOG_WARN("[%s] METHOD_NOT_FOUND (%s)", clientIp.c_str(), url.c_str());
+            LOG_WARN("[%s] 400 BAD REQUEST - Request does not contain clientId (%s)", clientIp.c_str(), url.c_str());
         }
     } else {
         if (url.rfind("/admin/resetClientStatusList", 0) == 0) {
             resultCode = resetClientStatusList(data, resp);
         } else {
-            LOG_WARN("[%s] METHOD_NOT_FOUND (%s)", clientIp.c_str(), url.c_str());
+            LOG_WARN("[%s] 404 NOT FOUND (%s)", clientIp.c_str(), url.c_str());
         }
     }
 

--- a/src/cc/Service.cpp
+++ b/src/cc/Service.cpp
@@ -62,13 +62,20 @@ void Service::release()
     uv_mutex_unlock(&m_mutex);
 }
 
-unsigned Service::handleGET(const Options* options, const std::string& url, const std::string& clientId, std::string& resp)
+unsigned Service::handleGET(const Options* options, const std::string& url, const std::string& clientIp, const std::string& clientId, std::string& resp)
 {
     uv_mutex_lock(&m_mutex);
 
     unsigned resultCode = MHD_HTTP_NOT_FOUND;
 
-    LOG_INFO("GET(url='%s', clientId='%s')", url.c_str(), clientId.c_str());
+    std::string params;
+    if (!clientId.empty())
+    {
+        params += "?clientId=";
+        params += clientId;
+    }
+
+    LOG_INFO("[%s] GET '%s%s'", clientIp.c_str(), url.c_str(), params.c_str());
 
     if (url == "/") {
         resultCode = getAdminPage(options, resp);
@@ -82,10 +89,12 @@ unsigned Service::handleGET(const Options* options, const std::string& url, cons
                 resultCode = getClientCommand(clientId, resp);
             } else if (url.rfind("/admin/getClientLog", 0) == 0) {
                 resultCode = getClientLog(clientId, resp);
+            } else {
+                LOG_WARN("[%s] METHOD_NOT_FOUND (%s)", clientIp.c_str(), url.c_str());
             }
         }
         else {
-            LOG_ERR("Request does not contain clientId: %s", url.c_str());
+            LOG_ERR("[%s] Request does not contain clientId: %s", clientIp.c_str(), url.c_str());
         }
     }
 
@@ -101,17 +110,32 @@ unsigned Service::handlePOST(const Options* options, const std::string& url, con
 
     unsigned resultCode = MHD_HTTP_NOT_FOUND;
 
-    LOG_INFO("POST(url='%s', clientIp='%s', clientId='%s', dataLen='%d')",
-             url.c_str(), clientIp.c_str(), clientId.c_str(), data.length());
+    std::string params;
+    if (!clientId.empty())
+    {
+        params += "?clientId=";
+        params += clientId;
+    }
 
-    if (url.rfind("/client/setClientStatus", 0) == 0) {
-        resultCode = setClientStatus(options, clientIp, clientId, data, resp);
-    } else if (url.rfind("/admin/setClientConfig", 0) == 0 || url.rfind("/client/setClientConfig", 0) == 0) {
-        resultCode = setClientConfig(options, clientId, data, resp);
-    } else if (url.rfind("/admin/setClientCommand", 0) == 0) {
-        resultCode = setClientCommand(clientId, data, resp);
-    } else if (url.rfind("/admin/resetClientStatusList", 0) == 0) {
-        resultCode = resetClientStatusList(data, resp);
+    LOG_INFO("[%s] POST '%s%s', dataLen='%d'",
+             clientIp.c_str(), url.c_str(), params.c_str(), data.length());
+
+    if (!clientId.empty()) {
+        if (url.rfind("/client/setClientStatus", 0) == 0) {
+            resultCode = setClientStatus(options, clientIp, clientId, data, resp);
+        } else if (url.rfind("/admin/setClientConfig", 0) == 0 || url.rfind("/client/setClientConfig", 0) == 0) {
+            resultCode = setClientConfig(options, clientId, data, resp);
+        } else if (url.rfind("/admin/setClientCommand", 0) == 0) {
+            resultCode = setClientCommand(clientId, data, resp);
+        } else {
+            LOG_WARN("[%s] METHOD_NOT_FOUND (%s)", clientIp.c_str(), url.c_str());
+        }
+    } else {
+        if (url.rfind("/admin/resetClientStatusList", 0) == 0) {
+            resultCode = resetClientStatusList(data, resp);
+        } else {
+            LOG_WARN("[%s] METHOD_NOT_FOUND (%s)", clientIp.c_str(), url.c_str());
+        }
     }
 
     uv_mutex_unlock(&m_mutex);
@@ -227,8 +251,6 @@ unsigned Service::setClientStatus(const Options* options, const std::string& cli
 
     rapidjson::Document document;
     if (!document.Parse(data.c_str()).HasParseError()) {
-        LOG_INFO("Status from client: %s", clientId.c_str());
-
         ClientStatus clientStatus;
         clientStatus.parseFromJson(document);
         clientStatus.setExternalIp(clientIp);
@@ -245,7 +267,8 @@ unsigned Service::setClientStatus(const Options* options, const std::string& cli
             m_clientCommand.erase(clientId);
         }
     } else {
-        LOG_ERR("Parse Error Occured: %d", document.GetParseError());
+        LOG_ERR("[%s] ClientStatus for client '%s' - Parse Error Occured: %d",
+                clientIp.c_str(), clientId.c_str(), document.GetParseError());
     }
 
     return resultCode;

--- a/src/cc/Service.h
+++ b/src/cc/Service.h
@@ -42,7 +42,7 @@ public:
     static bool start();
     static void release();
 
-    static unsigned handleGET(const Options* options, const std::string& url, const std::string& clientId, std::string& resp);
+    static unsigned handleGET(const Options* options, const std::string& url, const std::string& clientIp, const std::string& clientId, std::string& resp);
     static unsigned handlePOST(const Options* options, const std::string& url, const std::string& clientIp, const std::string& clientId, const std::string& data, std::string& resp);
 
 private:

--- a/src/config_cc.json
+++ b/src/config_cc.json
@@ -1,7 +1,7 @@
 {
     "background": false,                            // true to run the cc-server in the background (no console)
     "colors": true,                                 // false to disable colored output
-    "log-file": null,                               // log all output to a file
+    "log-file": "server.log",                               // log all output to a file
     "syslog": false,                                // use system log for output messages
     "cc-server": {
         "port": 3344,                               // port the CC Server will listens on

--- a/src/version.h
+++ b/src/version.h
@@ -36,7 +36,7 @@
 #define APP_DESC      "XMRigCC CPU miner"
 #define APP_COPYRIGHT "Copyright (C) 2017- BenDr0id"
 #endif
-#define APP_VERSION   "1.7.0_beta1 (based on XMRig)"
+#define APP_VERSION   "1.7.0 (based on XMRig)"
 #define APP_DOMAIN    ""
 #define APP_SITE      "https://github.com/Bendr0id/xmrigCC"
 #define APP_KIND      "cpu"


### PR DESCRIPTION
# 1.7.0
- First official Release of XMRigCC-amd #33 #3
- Full integration of xmrigCC-amd into XMRigCCServer/Dashboard with GPUInfo / remote logging
- Config property to enable/disable config upload on startup (--cc-upload-config-on-startup) #80
- Refactoring of remote logging feature: #143
    - Only deltas will be send to the XMRigCCServer
    - Fetching miner log on dashboard upon need
    - Maximum lines of log history kept per miner can be configured on XMRigCCServer 
- Fix correct hugepages status on Dashboard
- Fix cpu affinity for single thread usage
- Add all needed security infos to XMRigCCServer logging to harden the server (f.e. fail2ban)
- Fix commandline params overwrite config.json #157
- Fix building miner with API support #145