### PR TITLE
OSX compile fix.

### DIFF
--- a/src/cc/GPUInfo.cpp
+++ b/src/cc/GPUInfo.cpp
@@ -40,14 +40,14 @@ rapidjson::Value GPUInfo::toJson(rapidjson::MemoryPoolAllocator <rapidjson::CrtA
     rapidjson::Value gpuInfo(rapidjson::kObjectType);
 
     gpuInfo.AddMember("name", rapidjson::StringRef(m_name.c_str()), allocator);
-    gpuInfo.AddMember("device_idx", m_deviceIdx, allocator);
-    gpuInfo.AddMember("raw_intensity", m_rawIntensity, allocator);
-    gpuInfo.AddMember("work_size", m_workSize, allocator);
-    gpuInfo.AddMember("max_work_size", m_maxWorkSize, allocator);
-    gpuInfo.AddMember("free_mem", m_freeMem, allocator);
-    gpuInfo.AddMember("mem_chunk", m_memChunk, allocator);
-    gpuInfo.AddMember("comp_mode", m_memChunk, allocator);
-    gpuInfo.AddMember("compute_units", m_memChunk, allocator);
+    gpuInfo.AddMember("device_idx", static_cast<uint64_t>(m_deviceIdx), allocator);
+    gpuInfo.AddMember("raw_intensity", static_cast<uint64_t>(m_rawIntensity), allocator);
+    gpuInfo.AddMember("work_size", static_cast<uint64_t>(m_workSize), allocator);
+    gpuInfo.AddMember("max_work_size", static_cast<uint64_t>(m_maxWorkSize), allocator);
+    gpuInfo.AddMember("free_mem", static_cast<uint64_t>(m_freeMem), allocator);
+    gpuInfo.AddMember("mem_chunk", static_cast<uint64_t>(m_memChunk), allocator);
+    gpuInfo.AddMember("comp_mode", static_cast<uint64_t>(m_memChunk), allocator);
+    gpuInfo.AddMember("compute_units", static_cast<uint64_t>(m_memChunk), allocator);
 
     return gpuInfo;
 }

--- a/src/cc/GPUInfo.cpp
+++ b/src/cc/GPUInfo.cpp
@@ -40,14 +40,14 @@ rapidjson::Value GPUInfo::toJson(rapidjson::MemoryPoolAllocator <rapidjson::CrtA
     rapidjson::Value gpuInfo(rapidjson::kObjectType);
 
     gpuInfo.AddMember("name", rapidjson::StringRef(m_name.c_str()), allocator);
-    gpuInfo.AddMember("device_idx", static_cast<uint64_t>(m_deviceIdx), allocator);
-    gpuInfo.AddMember("raw_intensity", static_cast<uint64_t>(m_rawIntensity), allocator);
-    gpuInfo.AddMember("work_size", static_cast<uint64_t>(m_workSize), allocator);
-    gpuInfo.AddMember("max_work_size", static_cast<uint64_t>(m_maxWorkSize), allocator);
-    gpuInfo.AddMember("free_mem", static_cast<uint64_t>(m_freeMem), allocator);
-    gpuInfo.AddMember("mem_chunk", static_cast<uint64_t>(m_memChunk), allocator);
-    gpuInfo.AddMember("comp_mode", static_cast<uint64_t>(m_memChunk), allocator);
-    gpuInfo.AddMember("compute_units", static_cast<uint64_t>(m_memChunk), allocator);
+    gpuInfo.AddMember("device_idx", static_cast<uint32_t>(m_deviceIdx), allocator); 
+    gpuInfo.AddMember("raw_intensity", static_cast<uint32_t>(m_rawIntensity), allocator); 
+    gpuInfo.AddMember("work_size", static_cast<uint32_t>(m_workSize), allocator); 
+    gpuInfo.AddMember("max_work_size", static_cast<uint32_t>(m_maxWorkSize), allocator); 
+    gpuInfo.AddMember("free_mem", static_cast<uint32_t>(m_freeMem), allocator); 
+    gpuInfo.AddMember("mem_chunk", m_memChunk, allocator); 
+    gpuInfo.AddMember("comp_mode", m_memChunk, allocator); 
+    gpuInfo.AddMember("compute_units", m_memChunk, allocator);
 
     return gpuInfo;
 }


### PR DESCRIPTION
Wrap GPU infos. https://github.com/Bendr0id/xmrigCC/issues/165

Windows build test needed...@Bendr0id

OSX build & test passed.
![image](https://user-images.githubusercontent.com/13107713/45329088-02e6c980-b55f-11e8-97bf-9c03309ff416.png)

Linux (Ubuntu 18.04LTS) build & test passed.
![image](https://user-images.githubusercontent.com/13107713/45329055-dc289300-b55e-11e8-9376-91edceefdbdf.png)

**EDIT:** I don't have any GPU yet and I'm not sure what is inside gpuInfos(free_mem?)... uint64 is probably overkill. Pls amend.